### PR TITLE
Fix for issue 125, unable to reconnect to bridge

### DIFF
--- a/frontend/src/store/modules/accounts.ts
+++ b/frontend/src/store/modules/accounts.ts
@@ -337,9 +337,10 @@ class AccountsModule extends VuexModule {
 		}
 
 		const previouslyConnected = localStorage.getItem('onboard.js:last_connected_wallet')
-		const wallets = previouslyConnected
-			? await this.onboard.connectWallet({ autoSelect: previouslyConnected[0] })
-			: await this.onboard.connectWallet()
+		const wallets =
+			previouslyConnected && typeof previouslyConnected != 'string'
+				? await this.onboard.connectWallet({ autoSelect: previouslyConnected[0] })
+				: await this.onboard.connectWallet()
 		// check if the user is connected to a supported network
 		const chainId = wallets[0].chains[0].id
 		if (!new Networks().getSupportedNetworks().find((network) => network.chainId === chainId)) {


### PR DESCRIPTION
Fixes Issue #125, which meant unable to reconnect to bridge if localstorage.onboard.js:last_connected_wallet was set to an empty array. Reading it in those cases resulted in it being parsed as a string, so previouslyConnected[0] was '['.

Fix tested in Desktop Browser, Metamask mobile not tested.